### PR TITLE
Add Cancel method and Done chanel

### DIFF
--- a/unbounded_chan_test.go
+++ b/unbounded_chan_test.go
@@ -152,7 +152,10 @@ func TestCancel(t *testing.T) {
 				select {
 				case <-ch.Done:
 					return
-				case _ = <-ch.Out:
+				case _, ok := <-ch.Out:
+					if !ok {
+						return
+					}
 				}
 			}
 		}()


### PR DESCRIPTION
Although it is feasible to rely on `close(ch.In)` to cancel the process, it is necessary to ensure that `close(ch.In)` must be executed after `ch.In<-v` when using it.
It is inconvenient, because the two may be in different goroutine.
So I suggest providing additional channels to handle this.