### PR TITLE
chan: reduce the memory allocation

### DIFF
--- a/unbounded_chan.go
+++ b/unbounded_chan.go
@@ -19,14 +19,14 @@ type UnboundedChan[T any] struct {
 // Len returns len of In plus len of Out plus len of buffer.
 // It is not accurate and only for your evaluating approximate number of elements in this chan,
 // see https://github.com/smallnest/chanx/issues/7.
-func (c UnboundedChan[T]) Len() int {
+func (c *UnboundedChan[T]) Len() int {
 	return len(c.In) + c.BufLen() + len(c.Out)
 }
 
 // BufLen returns len of the buffer.
 // It is not accurate and only for your evaluating approximate number of elements in this chan,
 // see https://github.com/smallnest/chanx/issues/7.
-func (c UnboundedChan[T]) BufLen() int {
+func (c *UnboundedChan[T]) BufLen() int {
 	return int(atomic.LoadInt64(&c.bufCount))
 }
 

--- a/unbounded_chan_test.go
+++ b/unbounded_chan_test.go
@@ -151,3 +151,31 @@ func TestGetDataWithGoleak(t *testing.T) {
 		ch.In <- int64(i)
 	}
 }
+
+func BenchmarkUnboundedChanLen(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := NewUnboundedChanSize[int64](ctx, 10, 50, 100)
+	for i := 1; i < 200; i++ {
+		ch.In <- int64(i)
+	}
+	// Benchmark the Len method
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ch.Len()
+	}
+}
+
+func BenchmarkUnboundedBufLen(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := NewUnboundedChanSize[int64](ctx, 10, 50, 100)
+	for i := 1; i < 200; i++ {
+		ch.In <- int64(i)
+	}
+	// Benchmark the Len method
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ch.BufLen()
+	}
+}


### PR DESCRIPTION
In our scenario, the Len function may frequently invoked.

before:

```
go test -benchmem -run=^$ -bench ^BenchmarkUnbounded github.com/smallnest/chanx  
goos: darwin
goarch: arm64
pkg: github.com/smallnest/chanx
BenchmarkUnboundedChanLen-12            65669220                18.17 ns/op           32 B/op          1 allocs/op
BenchmarkUnboundedBufLen-12             69060109                18.27 ns/op           32 B/op          1 allocs/op
```

after

```
goos: darwin
goarch: arm64
pkg: github.com/smallnest/chanx
BenchmarkUnboundedChanLen-12            1000000000               0.2879 ns/op          0 B/op          0 allocs/op
BenchmarkUnboundedBufLen-12             1000000000               0.2846 ns/op          0 B/op          0 allocs/op
```